### PR TITLE
Call contiguous() after permute() in the pytorch model

### DIFF
--- a/pytorch/model.py
+++ b/pytorch/model.py
@@ -48,7 +48,7 @@ def get_graph_feature(x, k=20, idx=None):
     feature = feature.view(batch_size, num_points, k, num_dims) 
     x = x.view(batch_size, num_points, 1, num_dims).repeat(1, 1, k, 1)
     
-    feature = torch.cat((feature-x, x), dim=3).permute(0, 3, 1, 2)
+    feature = torch.cat((feature-x, x), dim=3).permute(0, 3, 1, 2).contiguous()
   
     return feature
 


### PR DESCRIPTION
This avoids an error in some versions (e.g., 1.4) of PyTorch, and also brings sizable speed improvement.